### PR TITLE
call before _build_pk_filter since $delete_ref will be empty afterwards

### DIFF
--- a/lib/Net/Amazon/DynamoDB.pm
+++ b/lib/Net/Amazon/DynamoDB.pm
@@ -873,7 +873,7 @@ sub batch_write_item {
                         $request_ref->{ $key } = { $type => $value };
                     }
 
-                    # no matter success or failure, remove it first
+                    # no matter success or failure, remove cache first
                     if ( $self->_cache_enabled( $args_ref ) ) {
                         my $cache_key = $self->_cache_key_single( $table, $put_ref );
                         $self->cache->remove( $cache_key );
@@ -884,14 +884,15 @@ sub batch_write_item {
             # delete ..
             else {
                 foreach my $delete_ref( @operations ) {
-                    push @$table_requests_ref, { 'DeleteRequest' => { Key => my $request_ref = {} } };
-                    $self->_build_pk_filter( $table, $delete_ref, $request_ref );
-
-                    # no matter success or failure, remove it first
+                    # no matter success or failure, remove cache first
+                    # call before _build_pk_filter since $delete_ref will be empty afterwards
                     if ( $self->_cache_enabled( $args_ref ) ) {
                         my $cache_key = $self->_cache_key_single( $table, $delete_ref );
                         $self->cache->remove( $cache_key );
                     }
+
+                    push @$table_requests_ref, { 'DeleteRequest' => { Key => my $request_ref = {} } };
+                    $self->_build_pk_filter( $table, $delete_ref, $request_ref );
                 }
             }
         }


### PR DESCRIPTION
Sorry, the previous patch still have issue for delete in batch_write_item. this one fixes.

Thanks
