### PR TITLE
fixed: Wide character in HTTP request (bytes required) When DateTime set non Ascii locale.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ WriteMakefile(
         'DateTime::Format::Strptime' => 0,
         'DateTime::TimeZone' => 0,
         'DateTime::TimeZone::Local' => 0,
+        'HTTP::Date' => 0,
         'Digest::SHA' => 0,
         'HTTP::Request' => 0,
         'JSON' => 0,

--- a/lib/Net/Amazon/DynamoDB.pm
+++ b/lib/Net/Amazon/DynamoDB.pm
@@ -72,6 +72,7 @@ use Data::Dumper;
 use DateTime::Format::HTTP;
 use DateTime::Format::Strptime;
 use DateTime;
+use HTTP::Date qw/ time2str /;
 use Digest::SHA qw/ sha1_hex sha256_hex sha384_hex sha256 hmac_sha256_base64 /;
 use HTTP::Request;
 use JSON;
@@ -2066,7 +2067,7 @@ sub request {
     $json = $self->json->encode( $json ) if ref $json;
 
     # get date
-    my $http_date = DateTime::Format::HTTP->format_datetime( DateTime->now );
+    my $http_date = time2str( time );
 
     # build signable content
     #$json is already utf8 encoded via json encode


### PR DESCRIPTION
Hi.

When DateTime is set non Ascii locale, httpdate is bad format.
Wide character in HTTP request (bytes required) .

here's fix.

regards
