### PR TITLE
Emphasize that 'host' sets the region

### DIFF
--- a/lib/Net/Amazon/DynamoDB.pm
+++ b/lib/Net/Amazon/DynamoDB.pm
@@ -172,7 +172,8 @@ has json => ( isa => 'JSON', is => 'rw', default => sub { JSON->new()->canonical
 
 =head2 host
 
-DynamoDB API Hostname
+DynamoDB API Hostname. Your table will be in this region only. Table names do not
+have to be unique across regions.
 
 Default: dynamodb.us-east-1.amazonaws.com
 


### PR DESCRIPTION
This is my first time using AWS and I thought that the tables would be replicated across regions. I added a note to emphasize that that is not true.
