### PR TITLE
cache in batch_get_item

### DIFF
--- a/lib/Net/Amazon/DynamoDB.pm
+++ b/lib/Net/Amazon/DynamoDB.pm
@@ -1434,7 +1434,7 @@ sub batch_get_item {
                 $cache_key{$table}{$key_ref->{$hash_key}} = $cache_key;
                 my $cached = $self->cache->thaw( $cache_key );
                 if (defined $cached) {
-                    $cache_res{ $table_out } = [];
+                    $cache_res{ $table_out } ||= [];
                     push @{ $cache_res{ $table_out } }, $cached;
                     next;
                 }


### PR DESCRIPTION
Hi

it's a simple patch for cache in batch_get_item.

few notes:
- we do set cache on the returned body. it should not effect any bad but saves get_item too.
- we only return directly when there isn't any live request. we do not MIX the cache with the live request. (it's more simple than request less and merge the result, but feel free to do the merge).

let me know if you have any issue and I'll be very glad to hear any comments on it.

Thanks
